### PR TITLE
Include version info for methods in GAPI XML output

### DIFF
--- a/bindinate/Bindings.csproj.template
+++ b/bindinate/Bindings.csproj.template
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/bindinate/Bindings.csproj.template
+++ b/bindinate/Bindings.csproj.template
@@ -13,8 +13,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <OutputPath>bin\#PROFILE#\Debug</OutputPath>
+    <DefineConstants>DEBUG;#DEFINES#</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -23,7 +23,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
+    <OutputPath>bin\#PROFILE#\Release</OutputPath>
+    <DefineConstants>#DEFINES#</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/bindinate/Bindings.sln.BuildConfigs.template
+++ b/bindinate/Bindings.sln.BuildConfigs.template
@@ -1,0 +1,4 @@
+		{#PROJECT_GUID#}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{#PROJECT_GUID#}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{#PROJECT_GUID#}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{#PROJECT_GUID#}.Release|Any CPU.Build.0 = Release|Any CPU

--- a/bindinate/Bindings.sln.ProjDefs.template
+++ b/bindinate/Bindings.sln.ProjDefs.template
@@ -1,0 +1,2 @@
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "#NAME#", "sources\\#NAME#.csproj", "{#PROJECT_GUID#}"
+EndProject

--- a/bindinate/Bindings.sln.template
+++ b/bindinate/Bindings.sln.template
@@ -1,20 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "#NAME#", "sources\#NAME#.csproj", "{#PROJECT_GUID#}"
-EndProject
+#PROJECT_DEFS#
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{#PROJECT_GUID#}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{#PROJECT_GUID#}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{#PROJECT_GUID#}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{#PROJECT_GUID#}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = sources\#NAME#.csproj
+#BUILD_CONFIGS#
 	EndGlobalSection
 EndGlobal

--- a/bindinate/Makefile-docs.am.template
+++ b/bindinate/Makefile-docs.am.template
@@ -8,7 +8,7 @@ docsdir = $(datadir)
 docs_DATA =
 endif
 
-ASSEMBLIES = $(top_srcdir)/out/$(ASSEMBLY_NAME).dll
+ASSEMBLIES = $(top_srcdir)/out/*/$(ASSEMBLY_NAME).dll
 
 UPDATE_ASSEMBLIES = $(addprefix -assembly:, $(ASSEMBLIES))
 

--- a/bindinate/Makefile.am
+++ b/bindinate/Makefile.am
@@ -1,3 +1,3 @@
 bin_SCRIPTS = bindinate
 bindinatedir = $(libdir)/bindinator
-bindinate_DATA = gir2gapi.xslt preprocess.xslt merge.xslt configure.ac.template Makefile.am.template AssemblyInfo.cs.in autogen.sh pc.template Makefile-docs.am.template Makefile-glue.am.template Bindings.sln.template Bindings.csproj.template dependency.m4.template Bindings.sln.ProjDefs.template Bindings.sln.BuildConfigs.template
+bindinate_DATA = gir2gapi.xslt preprocess.xslt merge.xslt configure.ac.template Makefile.am.template AssemblyInfo.cs.in autogen.sh pc.template Makefile-docs.am.template Makefile-glue.am.template Bindings.sln.template Bindings.csproj.template dependency.m4.template Bindings.sln.ProjDefs.template Bindings.sln.BuildConfigs.template csproj.xslt

--- a/bindinate/Makefile.am
+++ b/bindinate/Makefile.am
@@ -1,3 +1,3 @@
 bin_SCRIPTS = bindinate
 bindinatedir = $(libdir)/bindinator
-bindinate_DATA = gir2gapi.xslt preprocess.xslt merge.xslt configure.ac.template Makefile.am.template AssemblyInfo.cs.in autogen.sh pc.template Makefile-docs.am.template Makefile-glue.am.template Bindings.sln.template Bindings.csproj.template dependency.m4.template
+bindinate_DATA = gir2gapi.xslt preprocess.xslt merge.xslt configure.ac.template Makefile.am.template AssemblyInfo.cs.in autogen.sh pc.template Makefile-docs.am.template Makefile-glue.am.template Bindings.sln.template Bindings.csproj.template dependency.m4.template Bindings.sln.ProjDefs.template Bindings.sln.BuildConfigs.template

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -5,6 +5,8 @@ ASSEMBLY = $(ASSEMBLY_NAME).dll
 ASSEMBLY_CONFIG = $(ASSEMBLY).config
 OUTDIR = $(top_srcdir)/out
 GLUEDIR = $(srcdir)/glue
+SRC_FILES_XML = $(srcdir)/src_files.xml
+CSPROJ_XSLT = $(srcdir)/csproj.xslt
 
 gapidir = $(GAPIXMLDIR)
 gapi_DATA = $(API)
@@ -20,8 +22,9 @@ PROFILES =#PROFILES#
 
 DLLS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY))
 DLL_CONFIGS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY_CONFIG))
+CS_PROJECTS = $(foreach profile,$(PROFILES),$(srcdir)/$(ASSEMBLY_NAME)-$(profile).csproj)
 
-CLEANFILES = $(DLLS) $(DLL_CONFIGS) $(API)
+CLEANFILES = $(DLLS) $(DLL_CONFIGS) $(API) $(SRC_FILES_XML)
 
 DISTCLEANFILES = AssemblyInfo.cs
 
@@ -47,6 +50,22 @@ generated.sources: $(API)
 		--glue-includes=#GLUEINCLUDES# --gapidir=$(gapidir) \
 	 	--assembly-name=$(ASSEMBLY_NAME) && \
 	find generated/ -type f -name "*.cs" > generated.sources
+
+$(SRC_FILES_XML): generated.sources
+	echo "<SourceFiles>" > $(SRC_FILES_XML)
+	cat generated.sources | sed 's|\/|\\|g' | \
+		sed 's|\(.*\)|  \<Compile Include="\1" \/\>|g' >> $(SRC_FILES_XML)
+	echo "</SourceFiles>" >> $(SRC_FILES_XML)
+
+$(srcdir)/$(ASSEMBLY_NAME)-%.csproj: $(SRC_FILES_XML) $(CSPROJ_XSLT)
+	cp $@ $@.tmp
+	$(XSLTPROC) --stringparam srcListPath $(SRC_FILES_XML) $(CSPROJ_XSLT) $@.tmp | \
+		$(UNIX2DOS) > $@
+	$(MDTOOL) project-export -f:'MSBuild (Visual Studio 2012)' $@
+	rm $@.tmp
+
+.PHONY: csproj
+csproj: $(CS_PROJECTS)
 
 $(OUTDIR)/%/$(ASSEMBLY): $(build_sources) generated.sources
 	mkdir -p $(@D)

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -1,12 +1,14 @@
-RAW_API = $(ASSEMBLY_NAME)-api.raw
-API = $(ASSEMBLY_NAME)-api.xml
-METADATA = $(ASSEMBLY_NAME).metadata
-ASSEMBLY = $(ASSEMBLY_NAME).dll
-ASSEMBLY_CONFIG = $(ASSEMBLY).config
+RAW_API = $(srcdir)/$(ASSEMBLY_NAME)-api.raw
+API = $(srcdir)/$(ASSEMBLY_NAME)-api.xml
+METADATA = $(srcdir)/$(ASSEMBLY_NAME).metadata
+ASSEMBLY_DLL_NAME = $(ASSEMBLY_NAME).dll
+ASSEMBLY_CONFIG_NAME = $(ASSEMBLY_DLL_NAME).config
+ASSEMBLY_CONFIG = $(srcdir)/$(ASSEMBLY_CONFIG_NAME)
 OUTDIR = $(top_srcdir)/out
 GLUEDIR = $(srcdir)/glue
 SRC_FILES_XML = $(srcdir)/src_files.xml
 CSPROJ_XSLT = $(srcdir)/csproj.xslt
+GEN_SOURCES = $(srcdir)/generated.sources
 
 gapidir = $(GAPIXMLDIR)
 gapi_DATA = $(API)
@@ -14,19 +16,19 @@ gapi_DATA = $(API)
 # Add any extra source files you need here
 sources =
 
-build_sources = AssemblyInfo.cs $(sources)
+build_sources = $(srcdir)/AssemblyInfo.cs $(sources)
 
 PROFILES =#PROFILES#
 
 #DEFINES#
 
-DLLS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY))
-DLL_CONFIGS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY_CONFIG))
+DLLS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY_DLL_NAME))
+DLL_CONFIGS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY_CONFIG_NAME))
 CS_PROJECTS = $(foreach profile,$(PROFILES),$(srcdir)/$(ASSEMBLY_NAME)-$(profile).csproj)
 
-CLEANFILES = $(DLLS) $(DLL_CONFIGS) $(API) $(SRC_FILES_XML)
+CLEANFILES = $(DLLS) $(DLL_CONFIGS) $(API) $(GEN_SOURCES) $(SRC_FILES_XML)
 
-DISTCLEANFILES = AssemblyInfo.cs
+DISTCLEANFILES = $(srcdir)/AssemblyInfo.cs
 
 noinst_DATA = $(DLLS) $(DLL_CONFIGS)
 
@@ -34,26 +36,26 @@ EXTRA_DIST = \
 	$(RAW_API) \
 	$(sources) \
 	$(METADATA) \
-	AssemblyInfo.cs.in \
-	$(ASSEMBLY_NAME).snk \
+	$(srcdir)/AssemblyInfo.cs.in \
+	$(srcdir)/$(ASSEMBLY_NAME).snk \
 	$(ASSEMBLY_CONFIG)
 
-$(API): $(srcdir)/$(RAW_API) $(srcdir)/$(METADATA)
-	cp $(srcdir)/$(RAW_API) $(API)
+$(API): $(RAW_API) $(METADATA)
+	cp $(RAW_API) $(API)
 	chmod u+w $(API)
-	$(GAPI_FIXUP) --api=$(srcdir)/$(API) --metadata=$(srcdir)/$(METADATA)
+	$(GAPI_FIXUP) --api=$(API) --metadata=$(METADATA)
 
-generated.sources: $(API)
-	 $(GAPI_CODEGEN) --generate $(srcdir)/$(API) #REFAPIS# \
-		--outdir=generated \
+$(GEN_SOURCES): $(API)
+	$(GAPI_CODEGEN) --generate $(API) #REFAPIS# \
+		--outdir=$(srcdir)/generated \
 		--glue-filename=$(GLUEDIR)/generated.c --gluelib-name=#GLUELIBNAME# \
 		--glue-includes=#GLUEINCLUDES# --gapidir=$(gapidir) \
 	 	--assembly-name=$(ASSEMBLY_NAME) && \
-	find generated/ -type f -name "*.cs" > generated.sources
+	find $(srcdir)/generated/ -type f -name "*.cs" > $(GEN_SOURCES)
 
-$(SRC_FILES_XML): generated.sources
+$(SRC_FILES_XML): $(GEN_SOURCES)
 	echo "<SourceFiles>" > $(SRC_FILES_XML)
-	cat generated.sources | sed 's|\/|\\|g' | \
+	cat $(GEN_SOURCES) | sed 's|\/|\\|g' | \
 		sed 's|\(.*\)|  \<Compile Include="\1" \/\>|g' >> $(SRC_FILES_XML)
 	echo "</SourceFiles>" >> $(SRC_FILES_XML)
 
@@ -67,18 +69,17 @@ $(srcdir)/$(ASSEMBLY_NAME)-%.csproj: $(SRC_FILES_XML) $(CSPROJ_XSLT)
 .PHONY: csproj
 csproj: $(CS_PROJECTS)
 
-$(OUTDIR)/%/$(ASSEMBLY): $(build_sources) generated.sources
+$(OUTDIR)/%/$(ASSEMBLY_DLL_NAME): $(build_sources) $(GEN_SOURCES)
 	mkdir -p $(@D)
 	xargs $(CSC) -nowarn:169 -unsafe -target:library #REFERENCES# \
-		$(build_sources) -out:$@ -d:$($*_DEFINES) < generated.sources
+		$(build_sources) -out:$@ -d:$($*_DEFINES) < $(GEN_SOURCES)
 
-$(OUTDIR)/%/$(ASSEMBLY_CONFIG): $(srcdir)/$(ASSEMBLY_CONFIG)
+$(OUTDIR)/%/$(ASSEMBLY_CONFIG_NAME): $(ASSEMBLY_CONFIG)
 	mkdir -p $(@D)
-	cp $(srcdir)/$(ASSEMBLY_CONFIG) $@
+	cp $(ASSEMBLY_CONFIG) $@
 
 clean-local:
-	test -e generated.sources && xargs rm -f < generated.sources || true
-	rm -f generated.sources
+	test -e $(GEN_SOURCES) && xargs rm -f < $(GEN_SOURCES) || true
 
 install-data-local:
 	echo "NOT IMPLEMENTED! ($(GACUTIL) /i assembly_path /f $(GACUTIL_FLAGS))"

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -14,10 +14,12 @@ sources =
 
 build_sources = AssemblyInfo.cs $(sources)
 
-#PROFILES#
+PROFILES =#PROFILES#
 
-DLLS =#DLLS#
-DLL_CONFIGS =#DLL_CONFIGS#
+#DEFINES#
+
+DLLS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY))
+DLL_CONFIGS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY_CONFIG))
 
 CLEANFILES = $(DLLS) $(DLL_CONFIGS) $(API)
 

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -26,8 +26,6 @@ EXTRA_DIST = \
 	AssemblyInfo.cs.in \
 	$(ASSEMBLY_NAME).snk
 
-all: generated.sources $(ASSEMBLY)
-
 $(API): $(srcdir)/$(RAW_API) $(srcdir)/$(METADATA)
 	cp $(srcdir)/$(RAW_API) $(API)
 	chmod u+w $(API)

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -1,8 +1,9 @@
 RAW_API = $(ASSEMBLY_NAME)-api.raw
 API = $(ASSEMBLY_NAME)-api.xml
 METADATA = $(ASSEMBLY_NAME).metadata
-DLL = $(top_srcdir)/out/$(ASSEMBLY_NAME).dll
-DLLMAP = $(top_srcdir)/out/$(ASSEMBLY_NAME).dll.config
+ASSEMBLY = $(ASSEMBLY_NAME).dll
+ASSEMBLY_CONFIG = $(ASSEMBLY).config
+OUTDIR = $(top_srcdir)/out
 GLUEDIR = $(srcdir)/glue
 
 gapidir = $(GAPIXMLDIR)
@@ -13,18 +14,24 @@ sources =
 
 build_sources = AssemblyInfo.cs $(sources)
 
-CLEANFILES = $(DLL) $(API)
+#PROFILES#
 
-DISTCLEANFILES = AssemblyInfo.cs $(DLLMAP)
+DLLS =#DLLS#
+DLL_CONFIGS =#DLL_CONFIGS#
 
-noinst_DATA = $(DLL)
+CLEANFILES = $(DLLS) $(DLL_CONFIGS) $(API)
+
+DISTCLEANFILES = AssemblyInfo.cs
+
+noinst_DATA = $(DLLS) $(DLL_CONFIGS)
 
 EXTRA_DIST = \
 	$(RAW_API) \
 	$(sources) \
 	$(METADATA) \
 	AssemblyInfo.cs.in \
-	$(ASSEMBLY_NAME).snk
+	$(ASSEMBLY_NAME).snk \
+	$(ASSEMBLY_CONFIG)
 
 $(API): $(srcdir)/$(RAW_API) $(srcdir)/$(METADATA)
 	cp $(srcdir)/$(RAW_API) $(API)
@@ -39,18 +46,23 @@ generated.sources: $(API)
 	 	--assembly-name=$(ASSEMBLY_NAME) && \
 	find generated/ -type f -name "*.cs" > generated.sources
 
-$(DLL): $(build_sources) generated.sources
-	xargs $(CSC) -nowarn:169 -unsafe -target:library -out:$(DLL) \
-		#REFERENCES# $(build_sources) < generated.sources
+$(OUTDIR)/%/$(ASSEMBLY): $(build_sources) generated.sources
+	mkdir -p $(@D)
+	xargs $(CSC) -nowarn:169 -unsafe -target:library #REFERENCES# \
+		$(build_sources) -out:$@ -d:$($*_DEFINES) < generated.sources
+
+$(OUTDIR)/%/$(ASSEMBLY_CONFIG): $(srcdir)/$(ASSEMBLY_CONFIG)
+	mkdir -p $(@D)
+	cp $(srcdir)/$(ASSEMBLY_CONFIG) $@
 
 clean-local:
 	test -e generated.sources && xargs rm -f < generated.sources || true
 	rm -f generated.sources
 
 install-data-local:
-	echo "$(GACUTIL) /i $(DLL) /f $(GACUTIL_FLAGS)";  \
-        $(GACUTIL) /i $(DLL) /f $(GACUTIL_FLAGS) || exit 1;
+	echo "NOT IMPLEMENTED! ($(GACUTIL) /i assembly_path /f $(GACUTIL_FLAGS))"
+	exit 1
 
 uninstall-local:
-	echo "$(GACUTIL) /u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS)"; \
-        $(GACUTIL) /u $(ASSEMBLY_NAME) $(GACUTIL_FLAGS) || exit 1;
+	echo "NOT IMPLEMENTED! ($(GACUTIL) /u assembly_name $(GACUTIL_FLAGS))"
+	exit 1

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -121,6 +121,7 @@ fi
 
 PROFILES=
 DEFINES=
+DEFINES_VALS=
 
 SanitizeVersion () {
    echo $1 | tr '.' '_' | tr '-' '_' | tr ':' '_' | tr '~' '_'
@@ -185,8 +186,10 @@ for buildLibVersion in $BUILDLIBVERSIONS; do
 	# Add to define flags
 	define="${definesVar} = ${defines}"
 	if [ -z "${DEFINES}" ]; then
+		DEFINES_VALS="$defines"
 		DEFINES="$define"
 	else
+		DEFINES_VALS="${DEFINES_VALS} ${defines}"
 		DEFINES="${DEFINES}\\n${define}"
 	fi
 done
@@ -405,19 +408,43 @@ if [ ! -e $OUTDIR/sources/$NAME-sharp-api.raw ]; then
 fi
 
 # Create xbuild files (sln and csproj)
-PROJ_GUID="$(@UUIDGEN@ | tr [:lower:] [:upper:])"
-if [ ! -e "${OUTDIR}/${NAME}-sharp.sln" ]; then
-	cat @prefix@/lib/bindinator/Bindings.sln.template | \
-		sed "s,#NAME#,${NAME}-sharp,g" | \
-		sed "s,#PROJECT_GUID#,${PROJ_GUID},g" \
-		> "${OUTDIR}/${NAME}-sharp.sln"
-fi
-
-if [ ! -e "${OUTDIR}/sources/${NAME}-sharp.csproj" ]; then
+PROJ_DEFS=
+BUILD_CONFIGS=
+i=1
+for profile in $PROFILES; do
+	guid="$(@UUIDGEN@ | tr [:lower:] [:upper:])"
+	
+	projDef=$(cat @prefix@/lib/bindinator/Bindings.sln.ProjDefs.template | \
+		sed "s,#NAME#,${NAME}-sharp-${profile},g" | \
+		sed "s,#PROJECT_GUID#,${guid},g")
+	if [ -z "$PROJ_DEFS" ]; then
+		PROJ_DEFS="${projDef}"
+	else
+		PROJ_DEFS="${PROJ_DEFS}\n${projDef}"
+	fi
+	
+	buildConfig=$(cat @prefix@/lib/bindinator/Bindings.sln.BuildConfigs.template | \
+		sed "s,#PROJECT_GUID#,${guid},g")
+	if [ -z "$BUILD_CONFIGS" ]; then
+		BUILD_CONFIGS="${buildConfig}"
+	else
+		BUILD_CONFIGS="${BUILD_CONFIGS}\n${buildConfig}"
+	fi
+	
+	defines=$(echo $DEFINES_VALS | cut -d' ' -f$i | tr ',' ';')
 	cat @prefix@/lib/bindinator/Bindings.csproj.template | \
 		sed "s,#NAME#,${NAME}-sharp,g" | \
-		sed "s,#PROJECT_GUID#,${PROJ_GUID},g" | \
-		sed "s,#NAMESPACE#,${NS},g" \
-		> "${OUTDIR}/sources/${NAME}-sharp.csproj"
-fi
+		sed "s,#PROJECT_GUID#,${guid},g" | \
+		sed "s,#NAMESPACE#,${NS},g" | \
+		sed "s,#PROFILE#,${profile},g" | \
+		sed "s,#DEFINES#,${defines},g" | \
+		@UNIX2DOS@ > "${OUTDIR}/sources/${NAME}-sharp-${profile}.csproj"
+	
+	i=$((i+1))
+done
+
+cat @prefix@/lib/bindinator/Bindings.sln.template | \
+	@PERL@ -pe "s|#PROJECT_DEFS#|${PROJ_DEFS}|g" | \
+	@PERL@ -pe "s,#BUILD_CONFIGS#,${BUILD_CONFIGS},g" | \
+	@UNIX2DOS@ > "${OUTDIR}/${NAME}-sharp.sln"
 

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -16,6 +16,7 @@ Usage: bindinate [--package=PACKAGE --name=NAME --out=PATH --windowslibraryname=
 EOF
 }
 
+LISTVERSIONS=false
 for arg; do
   case "$arg" in
     --help | -h)
@@ -54,6 +55,9 @@ for arg; do
       ;;
     --build-libversions=*)
       BUILDLIBVERSIONS=$(echo $arg | sed -e 's,.*=,,' | tr ',' '\n' | sort -V)
+      ;;
+    --list-versions)
+      LISTVERSIONS=true
       ;;
   esac
 done
@@ -106,6 +110,12 @@ VERSION=`@XSLTPROC@ --stringparam type version @prefix@/lib/bindinator/preproces
 INCLUDES=`@XSLTPROC@ --stringparam type include @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE|tr ' ' ','`
 GAPI=`@XSLTPROC@ --stringparam type gapi @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE`
 LIBVERSIONS=`@XSLTPROC@ --stringparam type libversions @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE | tr ' ' '\n' | sort -V`
+
+if $LISTVERSIONS; then
+echo $LIBVERSIONS | tr '\n' ' '
+echo
+exit 0
+fi
 
 PROFILES=
 DLLS=

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -353,6 +353,10 @@ pkgconfig_DATA = $NAME-sharp-$VERSION.pc
 EXTRA_DIST = $NAME-sharp-$VERSION.pc.in
 DISTCLEANFILES = $NAME-sharp-$VERSION.pc
 
+.PHONY: csproj
+csproj:
+	\$(MAKE) -C sources csproj
+
 EOF
 
 sed "s,#REFERENCES#,$REF,g" @prefix@/lib/bindinator/Makefile.am.template|sed "s,#GLUELIBNAME#,$GLUELIB,g"| \
@@ -447,4 +451,6 @@ cat @prefix@/lib/bindinator/Bindings.sln.template | \
 	@PERL@ -pe "s|#PROJECT_DEFS#|${PROJ_DEFS}|g" | \
 	@PERL@ -pe "s,#BUILD_CONFIGS#,${BUILD_CONFIGS},g" | \
 	@UNIX2DOS@ > "${OUTDIR}/${NAME}-sharp.sln"
+
+cp @prefix@/lib/bindinator/csproj.xslt "${OUTDIR}/sources/csproj.xslt"
 

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -119,8 +119,7 @@ exit 0
 fi
 
 PROFILES=
-DLLS=
-DLL_CONFIGS=
+DEFINES=
 
 SanitizeVersion () {
    echo $1 | tr '.' '_' | tr '-' '_' | tr ':' '_' | tr '~' '_'
@@ -176,26 +175,19 @@ for buildLibVersion in $BUILDLIBVERSIONS; do
 		EFFECTIVEBUILDLIBVERSIONS="${EFFECTIVEBUILDLIBVERSIONS}\n${buildLibVersion}"
 	fi
 	
-	outdirVarRef='\$(OUTDIR)'
-	assemblyVarRef='\$(ASSEMBLY)'
-	assemblyConfigVarRef='\$(ASSEMBLY_CONFIG)'
-	
 	profileId=V_$(SanitizeVersion ${buildLibVersion})
-	dllVar=${profileId}_DLL
-	dllConfigVar=${dllVar}_CONFIG
 	definesVar=${profileId}_DEFINES
 	
-	profile="${dllVar} = ${outdirVarRef}/${profileId}/${assemblyVarRef}\\n${dllConfigVar} = ${outdirVarRef}/${profileId}/${assemblyConfigVarRef}\\n${definesVar} = ${defines}"
-	
 	# Add to build profiles
-	if [ -z "${PROFILES}" ]; then
-		PROFILES="$profile"
-	else
-		PROFILES="${PROFILES}\\n\\n${profile}"
-	fi
+	PROFILES="${PROFILES} ${profileId}"
 	
-	DLLS="${DLLS} \\\$(${dllVar})"
-	DLL_CONFIGS="${DLL_CONFIGS} \\\$(${dllConfigVar})"
+	# Add to define flags
+	define="${definesVar} = ${defines}"
+	if [ -z "${DEFINES}" ]; then
+		DEFINES="$define"
+	else
+		DEFINES="${DEFINES}\\n${define}"
+	fi
 done
 
 echo "PACKAGE: $PACKAGE"
@@ -361,7 +353,7 @@ EOF
 
 sed "s,#REFERENCES#,$REF,g" @prefix@/lib/bindinator/Makefile.am.template|sed "s,#GLUELIBNAME#,$GLUELIB,g"| \
 sed "s;#GLUEINCLUDES#;$INCLUDES;g" | sed "s,#REFAPIS#,$REFAPIS,g" | sed "s;#PROFILES#;$PROFILES;g" | \
-sed "s;#DLLS#;$DLLS;g" | sed "s;#DLL_CONFIGS#;$DLL_CONFIGS;g" > $OUTDIR/sources/Makefile.am
+sed "s;#DEFINES#;$DEFINES;g" > $OUTDIR/sources/Makefile.am
 
 sed "s,#GLUENAME#,$GLUENAME,g" @prefix@/lib/bindinator/Makefile-glue.am.template|sed "s,#GLUELIBNAME#,$GLUELIB,g"| \
 sed "s,#VERSION#,$GLUEVERSION,g"|sed "s,#MODVERSION#,$MODVERSION,g"|sed "s,#PREFIX#,$UNAME,g">$OUTDIR/sources/glue/Makefile.am

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -13,6 +13,7 @@ Usage: bindinate [--package=PACKAGE --name=NAME --out=PATH --windowslibraryname=
     --merge-with	       A comma separated list of gir files to merge in
     --regenerate	       Only regenerate the API xml, must be called from inside of the bindings directory
     --build-libversions    A comma separated list of version strings to create build profiles should for. E.g.: 2.2,2.4,2.10. If this argument is omitted, one build profile for the latest library version found in the GIR file is created. If the argument is 'all', a profile for each library version found is created.
+    --list-versions        List all versions of a GIRFILE, e.g.: 'bindinate --gir=Atk-1.0 --list-versions'. This is a query-only operation. No files will be created/changed.
 EOF
 }
 

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -107,49 +107,85 @@ INCLUDES=`@XSLTPROC@ --stringparam type include @prefix@/lib/bindinator/preproce
 GAPI=`@XSLTPROC@ --stringparam type gapi @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE`
 LIBVERSIONS=`@XSLTPROC@ --stringparam type libversions @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE | tr ' ' '\n' | sort -V`
 
+PROFILES=
+DLLS=
+DLL_CONFIGS=
+
+SanitizeVersion () {
+   echo $1 | tr '.' '_' | tr '-' '_' | tr ':' '_' | tr '~' '_'
+}
+
+EFFECTIVEBUILDLIBVERSIONS=
 if [ -z "$BUILDLIBVERSIONS" ]; then
-	EFFECTIVEBUILDLIBVERSIONS=$(echo "$LIBVERSIONS" | tail -n1)
+	BUILDLIBVERSIONS=$(echo "$LIBVERSIONS" | tail -n1)
 elif [ "$BUILDLIBVERSIONS" = "all" ]; then
-	EFFECTIVEBUILDLIBVERSIONS=$LIBVERSIONS
-else
-	EFFECTIVEBUILDLIBVERSIONS=
-	for buildLibVersion in $BUILDLIBVERSIONS; do
-		
-		# prevent duplicates
-		isDuplicate=false
-		for effectiveBuildLibVersion in $EFFECTIVEBUILDLIBVERSIONS; do
-			if [ "$buildLibVersion" = "$effectiveBuildLibVersion" ]; then
-				isDuplicate=true
-			fi
-		done
-		
-		if $isDuplicate; then
-			echo "Warning: Ignoring duplicate build library version '${buildLibVersion}'."
-			continue
-		fi
-		
-		# discard build lib versions that have no matching library version in the GIR file
-		match=false
-		for libVersion in $LIBVERSIONS; do
-			if [ "$buildLibVersion" = "$libVersion" ]; then
-				match=true
-				break
-			fi
-		done
-		
-		if ! $match; then
-			echo "Warning: Ignoring build library version '${buildLibVersion}', because no matching library version has been found in the GIR file."
-			continue
-		fi
-		
-		if [ -z "$EFFECTIVEBUILDLIBVERSIONS" ]; then
-			EFFECTIVEBUILDLIBVERSIONS="${buildLibVersion}"
-		else
-			EFFECTIVEBUILDLIBVERSIONS="${EFFECTIVEBUILDLIBVERSIONS}\n${buildLibVersion}"
-		fi
-		
-	done
+	BUILDLIBVERSIONS=$LIBVERSIONS
 fi
+
+for buildLibVersion in $BUILDLIBVERSIONS; do
+	# prevent duplicates
+	isDuplicate=false
+	for effectiveBuildLibVersion in $EFFECTIVEBUILDLIBVERSIONS; do
+		if [ "$buildLibVersion" = "$effectiveBuildLibVersion" ]; then
+			isDuplicate=true
+		fi
+	done
+	
+	if $isDuplicate; then
+		echo "Warning: Ignoring duplicate build library version '${buildLibVersion}'."
+		continue
+	fi
+	
+	# discard build lib versions that have no matching library version in the GIR file
+	# and construct DEFINES flags
+	match=false
+	defines=
+	for libVersion in $LIBVERSIONS; do
+		versionStr=V_$(SanitizeVersion ${libVersion})
+		if [ -z "$defines" ]; then
+			defines=${versionStr}
+		else
+			defines=${defines},${versionStr}
+		fi
+		
+		if [ "$buildLibVersion" = "$libVersion" ]; then
+			match=true
+			break
+		fi
+	done
+	
+	if ! $match; then
+		echo "Warning: Ignoring build library version '${buildLibVersion}', because no matching library version has been found in the GIR file."
+		continue
+	fi
+	
+	if [ -z "$EFFECTIVEBUILDLIBVERSIONS" ]; then
+		EFFECTIVEBUILDLIBVERSIONS="${buildLibVersion}"
+	else
+		EFFECTIVEBUILDLIBVERSIONS="${EFFECTIVEBUILDLIBVERSIONS}\n${buildLibVersion}"
+	fi
+	
+	outdirVarRef='\$(OUTDIR)'
+	assemblyVarRef='\$(ASSEMBLY)'
+	assemblyConfigVarRef='\$(ASSEMBLY_CONFIG)'
+	
+	profileId=V_$(SanitizeVersion ${buildLibVersion})
+	dllVar=${profileId}_DLL
+	dllConfigVar=${dllVar}_CONFIG
+	definesVar=${profileId}_DEFINES
+	
+	profile="${dllVar} = ${outdirVarRef}/${profileId}/${assemblyVarRef}\\n${dllConfigVar} = ${outdirVarRef}/${profileId}/${assemblyConfigVarRef}\\n${definesVar} = ${defines}"
+	
+	# Add to build profiles
+	if [ -z "${PROFILES}" ]; then
+		PROFILES="$profile"
+	else
+		PROFILES="${PROFILES}\\n\\n${profile}"
+	fi
+	
+	DLLS="${DLLS} \\\$(${dllVar})"
+	DLL_CONFIGS="${DLL_CONFIGS} \\\$(${dllConfigVar})"
+done
 
 echo "PACKAGE: $PACKAGE"
 echo "LIBS: $LIBS"
@@ -207,7 +243,7 @@ if [ -n "$REGENERATE" ]; then
 	exit 0
 fi
 
-cat >$OUTDIR/out/$DLLMAP <<EOF
+cat >$OUTDIR/sources/$DLLMAP <<EOF
 <configuration>
   <dllmap dll="$LIBRARYNAME" target="$SOLIB"/>
 </configuration>
@@ -313,7 +349,8 @@ DISTCLEANFILES = $NAME-sharp-$VERSION.pc
 EOF
 
 sed "s,#REFERENCES#,$REF,g" @prefix@/lib/bindinator/Makefile.am.template|sed "s,#GLUELIBNAME#,$GLUELIB,g"| \
-sed "s;#GLUEINCLUDES#;$INCLUDES;g" | sed "s,#REFAPIS#,$REFAPIS,g">$OUTDIR/sources/Makefile.am
+sed "s;#GLUEINCLUDES#;$INCLUDES;g" | sed "s,#REFAPIS#,$REFAPIS,g" | sed "s;#PROFILES#;$PROFILES;g" | \
+sed "s;#DLLS#;$DLLS;g" | sed "s;#DLL_CONFIGS#;$DLL_CONFIGS;g" > $OUTDIR/sources/Makefile.am
 
 sed "s,#GLUENAME#,$GLUENAME,g" @prefix@/lib/bindinator/Makefile-glue.am.template|sed "s,#GLUELIBNAME#,$GLUELIB,g"| \
 sed "s,#VERSION#,$GLUEVERSION,g"|sed "s,#MODVERSION#,$MODVERSION,g"|sed "s,#PREFIX#,$UNAME,g">$OUTDIR/sources/glue/Makefile.am

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -348,14 +348,14 @@ cat >$OUTDIR/Makefile.am <<EOF
 SUBDIRS = sources sources/glue doc
 
 pkgconfigdir = \$(libdir)/pkgconfig
-pkgconfig_DATA = $NAME-sharp-$VERSION.pc
+pkgconfig_DATA = \$(srcdir)/$NAME-sharp-$VERSION.pc
 
-EXTRA_DIST = $NAME-sharp-$VERSION.pc.in
-DISTCLEANFILES = $NAME-sharp-$VERSION.pc
+EXTRA_DIST = \$(srcdir)/$NAME-sharp-$VERSION.pc.in
+DISTCLEANFILES = \$(srcdir)/$NAME-sharp-$VERSION.pc
 
 .PHONY: csproj
 csproj:
-	\$(MAKE) -C sources csproj
+	\$(MAKE) -C \$(srcdir)/sources csproj
 
 EOF
 

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -2,7 +2,8 @@
 usage()
 {
 cat <<EOF
-Usage: bindinate [--package=PACKAGE --name=NAME --out=PATH --windowslibraryname=NAME -d=DEP1_VAR,dep1_pkg -d=DEP2_VAR,dep2_pkg] --gir=GIRFILE
+Usage: bindinate [--package=PACKAGE --name=NAME --out=PATH --windowslibraryname=NAME -d=DEP1_VAR,dep1_pkg -d=DEP2_VAR,dep2_pkg --merge-with=GIRFILE1,GIRFILE2 --regenerate --build-libversions=[V1,V2|all]] --gir=GIRFILE
+       bindinate --list-versions --gir=GIRFILE
     --gir=GIRFILE              Gir filename to process (without path or extension. It will be picked up from /usr/share/gir-1.0)
     --package=PACKAGE          name of pc file (if the gir data with the package name is wrong)
     --name=NAME                Name for the assembly
@@ -10,10 +11,10 @@ Usage: bindinate [--package=PACKAGE --name=NAME --out=PATH --windowslibraryname=
     --out=PATH                 Directory to place the generated bindings. default: $(pwd)/[Name of gir file]
     --windowslibraryname=NAME  Windows library file name, this is helpful when generating bindings targeting windows
     -d --dependency            Adds a dependency. Usage: '-d=DEP_VAR,dep_pkg_name', e.g.: '-d=GLIB_SHARP,glib-sharp-3.0'. This argument can be used multiple times.
-    --merge-with	       A comma separated list of gir files to merge in
-    --regenerate	       Only regenerate the API xml, must be called from inside of the bindings directory
-    --build-libversions    A comma separated list of version strings to create build profiles should for. E.g.: 2.2,2.4,2.10. If this argument is omitted, one build profile for the latest library version found in the GIR file is created. If the argument is 'all', a profile for each library version found is created.
-    --list-versions        List all versions of a GIRFILE, e.g.: 'bindinate --gir=Atk-1.0 --list-versions'. This is a query-only operation. No files will be created/changed.
+    --merge-with               A comma separated list of gir files to merge in
+    --regenerate               Only regenerate the API xml, must be called from inside of the bindings directory
+    --build-libversions        A comma separated list of version strings to create build profiles should for. E.g.: 2.2,2.4,2.10. If this argument is omitted, one build profile for the latest library version found in the GIR file is created. If the argument is 'all', a profile for each library version found is created.
+    --list-versions            List all versions of a GIRFILE, e.g.: 'bindinate --gir=Atk-1.0 --list-versions'. This is a query-only operation. No files will be created/changed.
 EOF
 }
 

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -10,8 +10,9 @@ Usage: bindinate [--package=PACKAGE --name=NAME --out=PATH --windowslibraryname=
     --out=PATH                 Directory to place the generated bindings. default: $(pwd)/[Name of gir file]
     --windowslibraryname=NAME  Windows library file name, this is helpful when generating bindings targeting windows
     -d --dependency            Adds a dependency. Usage: '-d=DEP_VAR,dep_pkg_name', e.g.: '-d=GLIB_SHARP,glib-sharp-3.0'. This argument can be used multiple times.
-    --merge-with	       A comma seperated list of gir files to merge in
+    --merge-with	       A comma separated list of gir files to merge in
     --regenerate	       Only regenerate the API xml, must be called from inside of the bindings directory
+    --build-libversions    A comma separated list of version strings to create build profiles should for. E.g.: 2.2,2.4,2.10. If this argument is omitted, one build profile for the latest library version found in the GIR file is created. If the argument is 'all', a profile for each library version found is created.
 EOF
 }
 
@@ -50,6 +51,9 @@ for arg; do
       ;;
     --gir=*) 
       GIRFILE=$(echo $arg|sed -e 's,.*=,,')
+      ;;
+    --build-libversions=*)
+      BUILDLIBVERSIONS=$(echo $arg | sed -e 's,.*=,,' | tr ',' '\n' | sort -V)
       ;;
   esac
 done
@@ -101,9 +105,56 @@ NS=`@XSLTPROC@ --stringparam type namespace @prefix@/lib/bindinator/preprocess.x
 VERSION=`@XSLTPROC@ --stringparam type version @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE`
 INCLUDES=`@XSLTPROC@ --stringparam type include @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE|tr ' ' ','`
 GAPI=`@XSLTPROC@ --stringparam type gapi @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE`
+LIBVERSIONS=`@XSLTPROC@ --stringparam type libversions @prefix@/lib/bindinator/preprocess.xslt $FULLGIRFILE | tr ' ' '\n' | sort -V`
+
+if [ -z "$BUILDLIBVERSIONS" ]; then
+	EFFECTIVEBUILDLIBVERSIONS=$(echo "$LIBVERSIONS" | tail -n1)
+elif [ "$BUILDLIBVERSIONS" = "all" ]; then
+	EFFECTIVEBUILDLIBVERSIONS=$LIBVERSIONS
+else
+	EFFECTIVEBUILDLIBVERSIONS=
+	for buildLibVersion in $BUILDLIBVERSIONS; do
+		
+		# prevent duplicates
+		isDuplicate=false
+		for effectiveBuildLibVersion in $EFFECTIVEBUILDLIBVERSIONS; do
+			if [ "$buildLibVersion" = "$effectiveBuildLibVersion" ]; then
+				isDuplicate=true
+			fi
+		done
+		
+		if $isDuplicate; then
+			echo "Warning: Ignoring duplicate build library version '${buildLibVersion}'."
+			continue
+		fi
+		
+		# discard build lib versions that have no matching library version in the GIR file
+		match=false
+		for libVersion in $LIBVERSIONS; do
+			if [ "$buildLibVersion" = "$libVersion" ]; then
+				match=true
+				break
+			fi
+		done
+		
+		if ! $match; then
+			echo "Warning: Ignoring build library version '${buildLibVersion}', because no matching library version has been found in the GIR file."
+			continue
+		fi
+		
+		if [ -z "$EFFECTIVEBUILDLIBVERSIONS" ]; then
+			EFFECTIVEBUILDLIBVERSIONS="${buildLibVersion}"
+		else
+			EFFECTIVEBUILDLIBVERSIONS="${EFFECTIVEBUILDLIBVERSIONS}\n${buildLibVersion}"
+		fi
+		
+	done
+fi
 
 echo "PACKAGE: $PACKAGE"
 echo "LIBS: $LIBS"
+echo "LIBVERSIONS: $(echo ${LIBVERSIONS} | tr '\n' ' ')"
+echo "BUILDLIBVERSIONS: $(echo ${EFFECTIVEBUILDLIBVERSIONS} | tr '\n' ' ')"
 
 if ! $(@PKG_CONFIG@ --exists $PACKAGE); then
 	echo "Package $PACKAGE not found, exiting"

--- a/bindinate/configure.ac.template
+++ b/bindinate/configure.ac.template
@@ -88,6 +88,24 @@ if test "x$GAPI_CODEGEN" = "xno"; then
 fi
 AC_SUBST(GAPI_CODEGEN)
 
+AC_PATH_PROG(XSLTPROC, xsltproc, no)
+if test "x$XSLTPROC" = "xno" ; then
+	AC_MSG_ERROR([xsltproc not found])
+fi
+AC_SUBST(XSLTPROC)
+
+AC_PATH_PROG(UNIX2DOS, unix2dos, no)
+if test "x$UNIX2DOS" = "xno" ; then
+	AC_MSG_ERROR([dos2unix and unix2dos not found])
+fi
+AC_SUBST(UNIX2DOS)
+
+AC_PATH_PROG(MDTOOL, mdtool, no)
+if test "x$MDTOOL" = "xno" ; then
+	AC_MSG_ERROR([mdtool not found])
+fi
+AC_SUBST(MDTOOL)
+
 dnl Check for monodoc
 AC_PATH_PROG(MDASSEMBLER, mdassembler, no)
 AC_PATH_PROG(MONODOCER, monodocer, no)

--- a/bindinate/csproj.xslt
+++ b/bindinate/csproj.xslt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:msb="http://schemas.microsoft.com/developer/msbuild/2003"
+	exclude-result-prefixes="xsl msb">
+	
+	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
+	<xsl:strip-space elements="*" />
+	
+	<xsl:param name="srcListPath" select="''" />
+	<xsl:variable name="srcList" select="document($srcListPath)" />
+	<xsl:variable name="msbUri" select="'http://schemas.microsoft.com/developer/msbuild/2003'" />
+	
+	<xsl:template match="node()|@*">
+		<xsl:copy>
+			<xsl:apply-templates select="node()|@*"/>
+		</xsl:copy>
+	</xsl:template>
+	
+	<xsl:template match="/msb:Project/msb:ItemGroup[msb:Compile]">
+		<xsl:element name="ItemGroup" namespace="{$msbUri}">
+			<xsl:apply-templates select="node()" />
+			
+			<xsl:variable name="existingCompiles" select="msb:Compile/@Include" />
+			<xsl:variable name="compiles" select="$srcList/SourceFiles/Compile/@Include" />
+			<xsl:for-each select="$compiles[not(.=$existingCompiles)]">
+				<xsl:element name="Compile" namespace="{$msbUri}">
+					<xsl:attribute name="Include">
+						<xsl:value-of select="." />
+					</xsl:attribute>
+				</xsl:element>
+			</xsl:for-each>
+		</xsl:element>
+	</xsl:template>
+</xsl:stylesheet>

--- a/bindinate/gir2gapi.xslt.in
+++ b/bindinate/gir2gapi.xslt.in
@@ -1059,8 +1059,18 @@
 			<xsl:if test="@disguised = '1'">
 				<xsl:attribute name="opaque">true</xsl:attribute>
 			</xsl:if>
+			<xsl:if test="@version">
+				<xsl:attribute name="version">
+					<xsl:value-of select="@version" />
+				</xsl:attribute>
+			</xsl:if>
 			<xsl:if test="@deprecated">
 				<xsl:attribute name="deprecated">true</xsl:attribute>
+			</xsl:if>
+			<xsl:if test="@deprecated-version">
+				<xsl:attribute name="deprecated-version">
+					<xsl:value-of select="@deprecated-version" />
+				</xsl:attribute>
 			</xsl:if>
 			<xsl:if test="$introspectable=0">
 				<xsl:attribute name="hidden">true</xsl:attribute>

--- a/bindinate/gir2gapi.xslt.in
+++ b/bindinate/gir2gapi.xslt.in
@@ -190,6 +190,11 @@
 								</xsl:with-param>
 							</xsl:call-template>
 						</xsl:attribute>
+						<xsl:call-template name="set-version-and-deprecated">
+							<xsl:with-param name="version" select="@version"/>
+							<xsl:with-param name="deprecated" select="@deprecated"/>
+							<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+						</xsl:call-template>
 					</constant>
 				</xsl:for-each>
 			</object>
@@ -277,6 +282,12 @@
 					<xsl:value-of select="$parent"/>
 				</xsl:attribute>
 			</xsl:if>
+			
+			<xsl:call-template name="set-version-and-deprecated">
+				<xsl:with-param name="version" select="@version"/>
+				<xsl:with-param name="deprecated" select="@deprecated"/>
+				<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+			</xsl:call-template>
 
 			<xsl:if test="gir:implements">
 				<implements>
@@ -359,6 +370,11 @@
 		</xsl:variable>
 
 		<union name="{$name}" cname="{exsl:node-set($type)/type/@ctype}">
+			<xsl:call-template name="set-version-and-deprecated">
+				<xsl:with-param name="version" select="@version"/>
+				<xsl:with-param name="deprecated" select="@deprecated"/>
+				<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+			</xsl:call-template>
 			<xsl:apply-templates>
 				<xsl:with-param name="external" select="$external"/>
 			</xsl:apply-templates>
@@ -418,6 +434,11 @@
 					<xsl:attribute name="hidden">
 						<xsl:value-of select="$hidden"/>
 					</xsl:attribute>
+					<xsl:call-template name="set-version-and-deprecated">
+						<xsl:with-param name="version" select="@version"/>
+						<xsl:with-param name="deprecated" select="@deprecated"/>
+						<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+					</xsl:call-template>
 					<xsl:if test="$nodename='boxed'">
 						<method name="GetType" cname="{@glib:get-type}" shared="true">
 							<return-type type="GType"/>
@@ -433,6 +454,11 @@
 					<xsl:attribute name="cname">
 						<xsl:value-of select="@c:type"/>
 					</xsl:attribute>
+					<xsl:call-template name="set-version-and-deprecated">
+						<xsl:with-param name="version" select="@version"/>
+						<xsl:with-param name="deprecated" select="@deprecated"/>
+						<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+					</xsl:call-template>
 					<xsl:for-each select="gir:field">
 						<xsl:apply-templates select="current()">
 							<xsl:with-param name="external" select="$external"/>
@@ -572,6 +598,11 @@
 			<xsl:if test="$shared = 'true'">
 				<xsl:attribute name="shared">true</xsl:attribute>
 			</xsl:if>
+			<xsl:call-template name="set-version-and-deprecated">
+				<xsl:with-param name="version" select="@version"/>
+				<xsl:with-param name="deprecated" select="@deprecated"/>
+				<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+			</xsl:call-template>
 
 			<!-- xsl:if test="gir:return-value/gir:type/@name != 'none'" -->
 			<xsl:for-each select="gir:return-value">
@@ -665,6 +696,11 @@
 				test="count(gir:parameters/gir:parameter) = 1 and exsl:node-set($consttypes)/types/ctor/type[@name=$t]">
 				<xsl:attribute name="disable_raw_ctor"/>
 			</xsl:if>
+			<xsl:call-template name="set-version-and-deprecated">
+				<xsl:with-param name="version" select="@version"/>
+				<xsl:with-param name="deprecated" select="@deprecated"/>
+				<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+			</xsl:call-template>
 
 			<xsl:if test="gir:parameters">
 				<xsl:element name="parameters">
@@ -707,6 +743,11 @@
 					<xsl:value-of select="translate(current()/@name,'-','_')"/>
 				</xsl:attribute>
 			</xsl:if>
+			<xsl:call-template name="set-version-and-deprecated">
+				<xsl:with-param name="version" select="@version"/>
+				<xsl:with-param name="deprecated" select="@deprecated"/>
+				<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+			</xsl:call-template>
 
 			<!-- xsl:if test="gir:return-value/gir:type/@name != 'none'" -->
 			<xsl:for-each select="gir:return-value">
@@ -777,6 +818,12 @@
 					<xsl:value-of select="@glib:get-type"/>
 				</xsl:attribute>
 			</xsl:if>
+			<xsl:call-template name="set-version-and-deprecated">
+				<xsl:with-param name="version" select="@version"/>
+				<xsl:with-param name="deprecated" select="@deprecated"/>
+				<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+			</xsl:call-template>
+			
 			<xsl:for-each select="gir:member">
 				<xsl:sort select="@value" data-type="number"/>
 
@@ -830,6 +877,12 @@
 					<xsl:value-of select="@glib:get-type"/>
 				</xsl:attribute>
 			</xsl:if>
+			<xsl:call-template name="set-version-and-deprecated">
+				<xsl:with-param name="version" select="@version"/>
+				<xsl:with-param name="deprecated" select="@deprecated"/>
+				<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+			</xsl:call-template>
+			
 			<xsl:for-each select="gir:member">
 				<xsl:sort select="@value" data-type="number"/>
 
@@ -936,81 +989,87 @@
 
 	<xsl:template match="gir:property[not(@private)]">
 		<xsl:param name="external"/>
-			<xsl:variable name="name">
-				<xsl:call-template name="capitalize">
-					<xsl:with-param name="string">
-						<xsl:choose>
-							<xsl:when test="../gir:method[@name = translate(current()/@name,'-','_')] or ../gir:virtual-method[@name = translate(current()/@name,'-','_')]">
-								<xsl:value-of select="@name"/>Prop
-							</xsl:when>
-							<xsl:otherwise>
-								<xsl:value-of select="@name"/>
-							</xsl:otherwise>
-						</xsl:choose>
-					</xsl:with-param>
-					<xsl:with-param name="sep">-</xsl:with-param>
+		<xsl:variable name="name">
+			<xsl:call-template name="capitalize">
+				<xsl:with-param name="string">
+					<xsl:choose>
+						<xsl:when test="../gir:method[@name = translate(current()/@name,'-','_')] or ../gir:virtual-method[@name = translate(current()/@name,'-','_')]">
+							<xsl:value-of select="@name"/>Prop
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="@name"/>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:with-param>
+				<xsl:with-param name="sep">-</xsl:with-param>
+			</xsl:call-template>
+		</xsl:variable>
+		<xsl:variable name="typemap">
+			<xsl:call-template name="map-type">
+				<xsl:with-param name="type" select="gir:type/@c:type"/>
+				<xsl:with-param name="name" select="gir:type/@name"/>
+				<xsl:with-param name="external" select="$external"/>
+			</xsl:call-template>
+		</xsl:variable>
+
+		<xsl:variable name="type">
+			<xsl:choose>
+				<xsl:when test="//*/gir:namespace/gir:enumeration[@c:type=gir:type/@c:type]">
+					<xsl:text>int</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="exsl:node-set($typemap)/type/@ctype"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:variable name="construct">
+			<xsl:choose>
+				<xsl:when test="@construct and @construct=1">true</xsl:when>
+				<xsl:otherwise>false</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:variable name="construct-only">
+			<xsl:choose>
+				<xsl:when test="@construct-only and @construct-only=1">true</xsl:when>
+				<xsl:otherwise>false</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:variable name="writable">
+			<xsl:choose>
+				<xsl:when test="@writable=1">
+					<xsl:text>true</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text>false</xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:variable name="readable">
+			<xsl:choose>
+				<xsl:when test="@readable=0">
+					<xsl:text>false</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text>true</xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:if test="$type!=''">
+			<property name="{$name}" cname="{@name}" type="{$type}" readable="{$readable}"
+				writeable="{$writable}" construct="{$construct}"
+				construct-only="{$construct-only}">
+				<xsl:call-template name="set-version-and-deprecated">
+					<xsl:with-param name="version" select="@version"/>
+					<xsl:with-param name="deprecated" select="@deprecated"/>
+					<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
 				</xsl:call-template>
-			</xsl:variable>
-			<xsl:variable name="typemap">
-				<xsl:call-template name="map-type">
-					<xsl:with-param name="type" select="gir:type/@c:type"/>
-					<xsl:with-param name="name" select="gir:type/@name"/>
-					<xsl:with-param name="external" select="$external"/>
-				</xsl:call-template>
-			</xsl:variable>
-
-			<xsl:variable name="type">
-				<xsl:choose>
-					<xsl:when test="//*/gir:namespace/gir:enumeration[@c:type=gir:type/@c:type]">
-						<xsl:text>int</xsl:text>
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:value-of select="exsl:node-set($typemap)/type/@ctype"/>
-					</xsl:otherwise>
-				</xsl:choose>
-			</xsl:variable>
-
-			<xsl:variable name="construct">
-				<xsl:choose>
-					<xsl:when test="@construct and @construct=1">true</xsl:when>
-					<xsl:otherwise>false</xsl:otherwise>
-				</xsl:choose>
-			</xsl:variable>
-
-			<xsl:variable name="construct-only">
-				<xsl:choose>
-					<xsl:when test="@construct-only and @construct-only=1">true</xsl:when>
-					<xsl:otherwise>false</xsl:otherwise>
-				</xsl:choose>
-			</xsl:variable>
-
-			<xsl:variable name="writable">
-				<xsl:choose>
-					<xsl:when test="@writable=1">
-						<xsl:text>true</xsl:text>
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:text>false</xsl:text>
-					</xsl:otherwise>
-				</xsl:choose>
-			</xsl:variable>
-
-			<xsl:variable name="readable">
-				<xsl:choose>
-					<xsl:when test="@readable=0">
-						<xsl:text>false</xsl:text>
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:text>true</xsl:text>
-					</xsl:otherwise>
-				</xsl:choose>
-			</xsl:variable>
-
-			<xsl:if test="$type!=''">
-				<property name="{$name}" cname="{@name}" type="{$type}" readable="{$readable}"
-					writeable="{$writable}" construct="{$construct}"
-					construct-only="{$construct-only}"/>
-			</xsl:if>
+			</property>
+		</xsl:if>
 		
 	</xsl:template>
 
@@ -1059,19 +1118,11 @@
 			<xsl:if test="@disguised = '1'">
 				<xsl:attribute name="opaque">true</xsl:attribute>
 			</xsl:if>
-			<xsl:if test="@version">
-				<xsl:attribute name="version">
-					<xsl:value-of select="@version" />
-				</xsl:attribute>
-			</xsl:if>
-			<xsl:if test="@deprecated">
-				<xsl:attribute name="deprecated">true</xsl:attribute>
-			</xsl:if>
-			<xsl:if test="@deprecated-version">
-				<xsl:attribute name="deprecated-version">
-					<xsl:value-of select="@deprecated-version" />
-				</xsl:attribute>
-			</xsl:if>
+			<xsl:call-template name="set-version-and-deprecated">
+				<xsl:with-param name="version" select="@version"/>
+				<xsl:with-param name="deprecated" select="@deprecated"/>
+				<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
+			</xsl:call-template>
 			<xsl:if test="$introspectable=0">
 				<xsl:attribute name="hidden">true</xsl:attribute>
 			</xsl:if>
@@ -1679,5 +1730,25 @@
 				<xsl:value-of select="$ctype"/>
 			</xsl:otherwise>
 		</xsl:choose>
+	</xsl:template>
+
+
+	<xsl:template name="set-version-and-deprecated">
+		<xsl:param name="version"/>
+		<xsl:param name="deprecated"/>
+		<xsl:param name="deprecated-version"/>
+		<xsl:if test="$version">
+			<xsl:attribute name="version">
+				<xsl:value-of select="$version" />
+			</xsl:attribute>
+		</xsl:if>
+		<xsl:if test="$deprecated">
+			<xsl:attribute name="deprecated">true</xsl:attribute>
+		</xsl:if>
+		<xsl:if test="$deprecated-version">
+			<xsl:attribute name="deprecated-version">
+				<xsl:value-of select="$deprecated-version" />
+			</xsl:attribute>
+		</xsl:if>
 	</xsl:template>
 </xsl:stylesheet>

--- a/bindinate/preprocess.xslt
+++ b/bindinate/preprocess.xslt
@@ -46,6 +46,8 @@ exclude-result-prefixes="xsl exsl gir c glib"
 	<xsl:strip-space elements="*" />
 
 	<xsl:param name="type" />
+	
+	<xsl:key name="version" match="/gir:repository/gir:namespace/*//@version" use="." />
 
 	<xsl:template match="/">
 		<xsl:choose>
@@ -71,6 +73,14 @@ exclude-result-prefixes="xsl exsl gir c glib"
 					<xsl:when test="gir:repository/gir:include[@name='Gdk']/@version='2.0'">2</xsl:when>
 					<xsl:otherwise>3</xsl:otherwise>
 				</xsl:choose>
+			</xsl:when>
+			
+			<!-- Using 'key' and 'generate-id' function to select version numbers distinctly. -->
+			<xsl:when test="$type='libversions'">
+				<xsl:for-each select="/gir:repository/gir:namespace/*//@version[generate-id() = generate-id(key('version', .)[1])]">
+					<xsl:value-of select="." />
+					<xsl:text> </xsl:text>
+				</xsl:for-each>
 			</xsl:when>
 		</xsl:choose>
 	</xsl:template>

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,17 @@ if test "x$UUIDGEN" = "xno" ; then
 fi
 AC_SUBST(UUIDGEN)
 
+AC_PATH_PROG(PERL, perl, no)
+if test "x$PERL" = "xno" ; then
+	AC_MSG_ERROR([perl not found])
+fi
+AC_SUBST(PERL)
+
+AC_PATH_PROG(UNIX2DOS, unix2dos, no)
+if test "x$UNIX2DOS" = "xno" ; then
+	AC_MSG_ERROR([dos2unix and unix2dos not found])
+fi
+AC_SUBST(UNIX2DOS)
 
 AC_CONFIG_FILES([
 	Makefile


### PR DESCRIPTION
This PR
 * makes the XSLT proc to also copy the version number of library elements to enable the generation of bindings that respect different library versions, in which elements have been introduced or declared deprecated. Those elements are:
   * method/function (2d0a662)
   * interface, object, struct, class_struct, boxed, callback, constructor, signal, enum, property (9714252)
 * adds a --build-libversions option and a version number extraction preprocessing step in bindinate (see commit message for details: b9928a5065ba620238bff356d878f96a45f05cb8)
 * removes the superfluous 'all' target in Makefile.am.template
 * adds support for generation of multiple build profiles based on library version (Details: 2b40ef1)
 * adds an option --list-versions to query all version numbers in GIR file (8f34f9d, 573c0a5)
 * adds a variable PROFILES in target bindings build that facilitates the build of specific build profiles instead of all profiles, which is the default (ef8ee3b)
 * adds support for xbuild files generation for all build profiles and a Makefile target 'csproj' to the generated bindings project build system that can be used to inject generated source files into the csproj files of all build profiles (373babf, a0a17d6)