### PR TITLE
XBuild file generation improvements

### DIFF
--- a/bindinate/Makefile.am
+++ b/bindinate/Makefile.am
@@ -1,3 +1,20 @@
 bin_SCRIPTS = bindinate
 bindinatedir = $(libdir)/bindinator
-bindinate_DATA = gir2gapi.xslt preprocess.xslt merge.xslt configure.ac.template Makefile.am.template AssemblyInfo.cs.in autogen.sh pc.template Makefile-docs.am.template Makefile-glue.am.template Bindings.sln.template Bindings.csproj.template dependency.m4.template Bindings.sln.ProjDefs.template Bindings.sln.BuildConfigs.template csproj.xslt
+bindinate_DATA = \
+	gir2gapi.xslt \
+	preprocess.xslt \
+	merge.xslt \
+	configure.ac.template \
+	Makefile.am.template \
+	AssemblyInfo.cs.in \
+	autogen.sh \
+	pc.template \
+	Makefile-docs.am.template \
+	Makefile-glue.am.template \
+	Bindings.sln.template \
+	Bindings.csproj.template \
+	dependency.m4.template \
+	Bindings.sln.ProjDefs.template \
+	Bindings.sln.BuildConfigs.template \
+	csproj.xslt \
+	custom.sources

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -25,7 +25,7 @@ DLLS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY_DLL_NAME))
 DLL_CONFIGS = $(foreach profile,$(PROFILES),$(OUTDIR)/$(profile)/$(ASSEMBLY_CONFIG_NAME))
 CS_PROJECTS = $(foreach profile,$(PROFILES),$(srcdir)/$(ASSEMBLY_NAME)-$(profile).csproj)
 
-CLEANFILES = $(DLLS) $(DLL_CONFIGS) $(API) $(GEN_SOURCES) $(SRC_FILES_XML)
+CLEANFILES = $(DLLS) $(DLL_CONFIGS) $(API) $(SRC_FILES_XML)
 
 DISTCLEANFILES = $(srcdir)/AssemblyInfo.cs
 
@@ -81,6 +81,7 @@ $(OUTDIR)/%/$(ASSEMBLY_CONFIG_NAME): $(ASSEMBLY_CONFIG)
 
 clean-local:
 	test -e $(GEN_SOURCES) && xargs rm -f < $(GEN_SOURCES) || true
+	rm -f $(GEN_SOURCES)
 
 install-data-local:
 	echo "NOT IMPLEMENTED! ($(GACUTIL) /i assembly_path /f $(GACUTIL_FLAGS))"

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -55,7 +55,8 @@ $(GEN_SOURCES): $(API)
 
 $(SRC_FILES_XML): $(GEN_SOURCES)
 	echo "<SourceFiles>" > $(SRC_FILES_XML)
-	cat $(GEN_SOURCES) | sed 's|\/|\\|g' | \
+	echo $(build_sources) | tr '[:blank:]' '\n' | cat - $(GEN_SOURCES) | \
+		grep -Ev '^[[:blank:]]*$$' | sed 's|\/|\\|g' | sed 's|^\.\\||g' | \
 		sed 's|\(.*\)|  \<Compile Include="\1" \/\>|g' >> $(SRC_FILES_XML)
 	echo "</SourceFiles>" >> $(SRC_FILES_XML)
 

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -72,8 +72,8 @@ csproj: $(CS_PROJECTS)
 
 $(OUTDIR)/%/$(ASSEMBLY_DLL_NAME): $(build_sources) $(GEN_SOURCES)
 	mkdir -p $(@D)
-	xargs $(CSC) -nowarn:169 -unsafe -target:library #REFERENCES# \
-		$(build_sources) -out:$@ -d:$($*_DEFINES) < $(GEN_SOURCES)
+	$(CSC) -nowarn:169 -unsafe -target:library #REFERENCES# \
+		$(build_sources) -out:$@ -d:$($*_DEFINES) @$(GEN_SOURCES)
 
 $(OUTDIR)/%/$(ASSEMBLY_CONFIG_NAME): $(ASSEMBLY_CONFIG)
 	mkdir -p $(@D)

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -14,7 +14,7 @@ CUSTOM_SOURCES = $(srcdir)/custom.sources
 gapidir = $(GAPIXMLDIR)
 gapi_DATA = $(API)
 
-sources = $(shell grep -Ev '\#.*$$' $(CUSTOM_SOURCES))
+sources = $(shell sed 's|\#.*$$||g' $(CUSTOM_SOURCES) | grep -Ev '^[[:blank:]]*$$')
 build_sources = $(srcdir)/AssemblyInfo.cs $(sources)
 
 PROFILES =#PROFILES#

--- a/bindinate/Makefile.am.template
+++ b/bindinate/Makefile.am.template
@@ -9,13 +9,12 @@ GLUEDIR = $(srcdir)/glue
 SRC_FILES_XML = $(srcdir)/src_files.xml
 CSPROJ_XSLT = $(srcdir)/csproj.xslt
 GEN_SOURCES = $(srcdir)/generated.sources
+CUSTOM_SOURCES = $(srcdir)/custom.sources
 
 gapidir = $(GAPIXMLDIR)
 gapi_DATA = $(API)
 
-# Add any extra source files you need here
-sources =
-
+sources = $(shell grep -Ev '\#.*$$' $(CUSTOM_SOURCES))
 build_sources = $(srcdir)/AssemblyInfo.cs $(sources)
 
 PROFILES =#PROFILES#
@@ -34,6 +33,7 @@ noinst_DATA = $(DLLS) $(DLL_CONFIGS)
 
 EXTRA_DIST = \
 	$(RAW_API) \
+	$(CUSTOM_SOURCES) \
 	$(sources) \
 	$(METADATA) \
 	$(srcdir)/AssemblyInfo.cs.in \
@@ -53,7 +53,7 @@ $(GEN_SOURCES): $(API)
 	 	--assembly-name=$(ASSEMBLY_NAME) && \
 	find $(srcdir)/generated/ -type f -name "*.cs" > $(GEN_SOURCES)
 
-$(SRC_FILES_XML): $(GEN_SOURCES)
+$(SRC_FILES_XML): $(GEN_SOURCES) $(CUSTOM_SOURCES)
 	echo "<SourceFiles>" > $(SRC_FILES_XML)
 	echo $(build_sources) | tr '[:blank:]' '\n' | cat - $(GEN_SOURCES) | \
 		grep -Ev '^[[:blank:]]*$$' | sed 's|\/|\\|g' | sed 's|^\.\\||g' | \

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -418,7 +418,14 @@ PROJ_DEFS=
 BUILD_CONFIGS=
 i=1
 for profile in $PROFILES; do
-	guid="$(@UUIDGEN@ | tr [:lower:] [:upper:])"
+	projPath="${OUTDIR}/sources/${NAME}-sharp-${profile}.csproj"
+	
+	guid=
+	if guidNodeVal=$(@XMLLINT@ --xpath "//*[local-name() = 'ProjectGuid']/text()" $projPath 2>/dev/null) ; then
+		guid=$(echo $guidNodeVal | sed 's|{*||g' | sed 's|}*||g')
+	else
+		guid="$(@UUIDGEN@ | tr [:lower:] [:upper:])"
+	fi
 	
 	projDef=$(cat @prefix@/lib/bindinator/Bindings.sln.ProjDefs.template | \
 		sed "s,#NAME#,${NAME}-sharp-${profile},g" | \
@@ -444,7 +451,7 @@ for profile in $PROFILES; do
 		sed "s,#NAMESPACE#,${NS},g" | \
 		sed "s,#PROFILE#,${profile},g" | \
 		sed "s,#DEFINES#,${defines},g" | \
-		@UNIX2DOS@ > "${OUTDIR}/sources/${NAME}-sharp-${profile}.csproj"
+		@UNIX2DOS@ > $projPath
 	
 	i=$((i+1))
 done

--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -367,6 +367,8 @@ sed "s,#GLUENAME#,$GLUENAME,g" @prefix@/lib/bindinator/Makefile-glue.am.template
 sed "s,#VERSION#,$GLUEVERSION,g"|sed "s,#MODVERSION#,$MODVERSION,g"|sed "s,#PREFIX#,$UNAME,g">$OUTDIR/sources/glue/Makefile.am
 
 cp @prefix@/lib/bindinator/AssemblyInfo.cs.in $OUTDIR/sources/.
+cp @prefix@/lib/bindinator/custom.sources $OUTDIR/sources/.
+
 cp @prefix@/lib/bindinator/autogen.sh $OUTDIR/.
 chmod +x $OUTDIR/autogen.sh
 mkdir -p $OUTDIR/m4

--- a/bindinate/csproj.xslt
+++ b/bindinate/csproj.xslt
@@ -18,11 +18,7 @@
 	
 	<xsl:template match="/msb:Project/msb:ItemGroup[msb:Compile]">
 		<xsl:element name="ItemGroup" namespace="{$msbUri}">
-			<xsl:apply-templates select="node()" />
-			
-			<xsl:variable name="existingCompiles" select="msb:Compile/@Include" />
-			<xsl:variable name="compiles" select="$srcList/SourceFiles/Compile/@Include" />
-			<xsl:for-each select="$compiles[not(.=$existingCompiles)]">
+			<xsl:for-each select="$srcList/SourceFiles/Compile/@Include">
 				<xsl:element name="Compile" namespace="{$msbUri}">
 					<xsl:attribute name="Include">
 						<xsl:value-of select="." />

--- a/bindinate/custom.sources
+++ b/bindinate/custom.sources
@@ -1,0 +1,2 @@
+# Add any custom source files you need here, e.g.:
+# ./custom/MyClass.cs

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,12 @@ if test "x$XSLTPROC" = "xno" ; then
 fi
 AC_SUBST(XSLTPROC)
 
+AC_PATH_PROG(XMLLINT, xmllint, no)
+if test "x$XMLLINT" = "xno" ; then
+	AC_MSG_ERROR([xmllint not found])
+fi
+AC_SUBST(XMLLINT)
+
 PKG_CHECK_MODULES(GIR, gobject-introspection-1.0, has_gir=true, has_gir=false)
 if test "x$has_gir" = "xfalse"; then
 	AC_MSG_ERROR([gobject-introspection not found, cannot determine gir directory])


### PR DESCRIPTION
This PR
 * changes the 'csproj' Makefile target so that custom source files are included as well as generated source files. Also, the custom source files list has been moved to a dedicated custom.sources file.
 * prevents existing csproj files from having their project guids overwritten during binding regeneration.
 * simplifies the compile command line by using the '@filename' syntax and fixes the clean target.