### PR TITLE
Use mcs instead gmcs to compile generated projects

### DIFF
--- a/bindinate/configure.ac.template
+++ b/bindinate/configure.ac.template
@@ -21,7 +21,7 @@ PKG_CHECK_MODULES(MONO_DEPENDENCY, mono >= 1.0, has_mono=true, has_mono=false)
 
 if test "x$has_mono" = "xtrue"; then
 	AC_PATH_PROG(RUNTIME, mono, no)
-	AC_PATH_PROG(CSC, gmcs, no)
+	AC_PATH_PROG(CSC, mcs, no)
 	LIB_PREFIX=.so
 	LIB_SUFFIX=
 else


### PR DESCRIPTION
Newer Mono versions have dropped gmcs and dmcs.