### PR TITLE
Only runs on BASH

### DIFF
--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 usage()
 {
 cat <<EOF


### PR DESCRIPTION
If /bin/sh isn't a link to /bin/bash on your system, bindinate returns the following error:
```
/usr/local/bin/bindinate: 96: function: not found
/usr/local/bin/bindinate: 107: Syntax error: "}" unexpected
```

So, it's probably the case that the script should be referring to bash.